### PR TITLE
make specUrl an environment variable

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,7 +21,7 @@ const config = {
       {
         specs: [{
           routePath: '/api',
-          specUrl: 'https://app.herondata.io/swagger/',
+          specUrl: process.env.SPEC_URL,
           layout: {
             title: 'API Reference'
           }


### PR DESCRIPTION
so we can test API schema changes in a docs staging env before releasing